### PR TITLE
stackblitz folder in express-basic-js and express-basic-ts templated

### DIFF
--- a/packages/create-servest/src/utils/helper.ts
+++ b/packages/create-servest/src/utils/helper.ts
@@ -30,6 +30,10 @@ export function toValidPackageName(projectName: string): string {
 export function copyDir(srcDir: string, destDir: string): void {
   const stat = fs.statSync(srcDir);
 
+  if (stat.isDirectory() && path.basename(srcDir) === '.stackblitz') {
+    return;
+  }
+
   if (stat.isDirectory()) {
     fs.mkdirSync(destDir, { recursive: true });
 

--- a/packages/create-servest/templates/express/express-basic-js/.stackblitz/config.json
+++ b/packages/create-servest/templates/express/express-basic-js/.stackblitz/config.json
@@ -1,0 +1,3 @@
+{
+  "defaultOpenedFiles": ["app.js"]
+}

--- a/packages/create-servest/templates/express/express-basic-ts/.stackblitz/config.json
+++ b/packages/create-servest/templates/express/express-basic-ts/.stackblitz/config.json
@@ -1,0 +1,3 @@
+{
+  "defaultOpenedFiles": ["app.ts"]
+}

--- a/packages/create-servest/templates/express/express-basic-ts/src/server.ts
+++ b/packages/create-servest/templates/express/express-basic-ts/src/server.ts
@@ -3,6 +3,8 @@ import app from './app';
 
 const port = process.env.PORT || 3000;
 
+console.log('port', port);
+
 app.listen(port, () => {
   console.log(`Server listening on port http://localhost:${port}`);
 });


### PR DESCRIPTION
stackblitz folder in express-basic-js and express-basic-ts templated added and copyDir function modified to skip this folder