### PR TITLE
create-servest 1.2.1~beta ready to publish

### DIFF
--- a/packages/create-servest/CHANGELOG.md
+++ b/packages/create-servest/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to **create-servest** will be documented here.
 
+## [1.2.1~beta] – 2025-10-17
+
+### Changed
+- Replaced `ts-node-dev` with `tsx` for improved performance and future compatibility.
+- Updated all Express templates’ development scripts:
+  - From `npm/pnpm/yarn run start:dev` → `npm/pnpm/yarn run start`.
+- Updated Express TypeScript templates’ start command:
+  - From `ts-node-dev --respawn --transpile-only src/server.ts` → `tsx watch src/server.ts`.
+
 ## [1.2.0] – 2025-09-01
 
 ### Added

--- a/packages/create-servest/package.json
+++ b/packages/create-servest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-servest",
-  "version": "1.2.0",
+  "version": "1.2.1~beta",
   "type": "module",
   "license": "MIT",
   "author": "Rashedin Islam <https://www.rashedin.dev>",

--- a/packages/create-servest/templates/express/express-basic-ts/package.json
+++ b/packages/create-servest/templates/express/express-basic-ts/package.json
@@ -6,7 +6,7 @@
   "description": "",
   "scripts": {
     "build": "tsc",
-    "start": "tsx watch ./src/server.ts",
+    "start": "tsx watch src/server.ts",
     "start:prod": "node dist/server.js"
   },
   "keywords": [],

--- a/packages/create-servest/templates/express/express-modular-ts/package.json
+++ b/packages/create-servest/templates/express/express-modular-ts/package.json
@@ -6,7 +6,7 @@
   "description": "",
   "scripts": {
     "build": "tsc",
-    "start": "tsx watch ./src/server.ts",
+    "start": "tsx watch src/server.ts",
     "start:prod": "node dist/server.js"
   },
   "keywords": [],

--- a/packages/create-servest/templates/express/express-mvc-ts/package.json
+++ b/packages/create-servest/templates/express/express-mvc-ts/package.json
@@ -6,7 +6,7 @@
   "description": "",
   "scripts": {
     "build": "tsc",
-    "start": "tsx watch ./src/server.ts",
+    "start": "tsx watch src/server.ts",
     "start:prod": "node dist/server.js"
   },
   "keywords": [],

--- a/packages/servest-addons/src/utils/add/addMongoose.ts
+++ b/packages/servest-addons/src/utils/add/addMongoose.ts
@@ -155,5 +155,7 @@ export async function addMongoose({
     console.log(yellow('👍 Could not find src/server or src/app to inject connectDB call.'));
   }
 
-  console.log(green('🎉 Mongoose setup completed!'));
+  // console.log(green(`🎉 Mongoose setup completed!, please import the MONGO_URI inside ${configDir}/connectDB.${isTypeScript ? 'ts' : 'js'}`));
+
+  console.log('🎉 Mongoose setup completed!');
 }


### PR DESCRIPTION
## [1.2.1~beta] – 2025-10-17

### Changed
- Replaced `ts-node-dev` with `tsx` for improved performance and future compatibility.
- Updated all Express templates’ development scripts:
  - From `npm/pnpm/yarn run start:dev` → `npm/pnpm/yarn run start`.
- Updated Express TypeScript templates’ start command:
  - From `ts-node-dev --respawn --transpile-only src/server.ts` → `tsx watch src/server.ts`.